### PR TITLE
Fixes endpoint generation and naming issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Zooper.Cheetah project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-05-01
+
+### Fixed
+- Fixed variable naming in generated endpoints to avoid duplicate declarations
+- Corrected SubscriptionEndpoint method signature in generated code
+- Added unique identifiers to variable names for multiple consumers
+
 ## [1.2.0] - 2025-05-01
 
 ### Added
@@ -14,9 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added optional parameter `enableDeadLettering` (defaults to true) to control dead letter functionality
 
 ### Changed
+- Changed generated endpoint code to use `SubscriptionEndpoint<T>` instead of `ReceiveEndpoint`
+  - Improved clarity with named variables for topic and subscription names
+  - Added comments to explain the purpose of each configuration section
+- Renamed the generated extension class from `ReceiveEndpointExtensions` to `MassTransitExtensions`
 - Refactored `ReceiveEndpointSourceGenerator` to remove magic strings, improving code maintainability
   - Extracted string constants for namespace names, file names, and other parameters
-  - Set proper value for `FileName` constant as "ReceiveEndpointExtensions"
+  - Set proper value for `FileName` constant as "MassTransitExtensions"
 
 ## [1.1.0] - 2025.04.23
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <Authors>Daniel Martin</Authors>
         <Company>Zooper</Company>
         <RepositoryUrl>https://github.com/zooper-lib/cheetah</RepositoryUrl>


### PR DESCRIPTION
Addresses several issues related to Azure Service Bus endpoint generation:

- Resolves variable naming conflicts in generated endpoints, preventing duplicate declarations.
- Corrects the SubscriptionEndpoint method signature in generated code.
- Introduces unique identifiers to variable names when configuring multiple consumers for the same event.
- Switches to using `SubscriptionEndpoint` for improved configuration.
- Enhances clarity by using named variables for topic and subscription names and adding explanatory comments.
- Renames the generated extension class to `MassTransitExtensions`.