### PR TITLE
Fixes topic and subscription configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,21 @@ All notable changes to the Zooper.Cheetah project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2025-05-01
+## [1.2.2] - 2025.05.01
+
+### Fixed
+
+- Corrected parameter order in SubscriptionEndpoint method calls (subscription name first, then topic path)
+- Updated topic name format to use the entity name directly instead of prefixing with service name
+
+## [1.2.1] - 2025.05.01
 
 ### Fixed
 - Fixed variable naming in generated endpoints to avoid duplicate declarations
 - Corrected SubscriptionEndpoint method signature in generated code
 - Added unique identifiers to variable names for multiple consumers
 
-## [1.2.0] - 2025-05-01
+## [1.2.0] - 2025.05.01
 
 ### Added
 - Dead letter queue support in generated receive endpoints

--- a/Zooper.Cheetah.Generators.AzureServiceBus/ReceiveEndpointSourceGenerator.cs
+++ b/Zooper.Cheetah.Generators.AzureServiceBus/ReceiveEndpointSourceGenerator.cs
@@ -143,16 +143,16 @@ public class ReceiveEndpointSourceGenerator : IIncrementalGenerator
 
                         // Generate variable declarations for topic and subscription names with unique names
                         sb.AppendLine($"        // topic name for {evtSym.Name}");
-                        sb.AppendLine($"        var {topicVarName} = serviceName + \"{EndpointSeparator}{entityName}\";");
+                        sb.AppendLine($"        var {topicVarName} = \"{entityName}\";");
                         sb.AppendLine($"        // subscription name");
                         sb.AppendLine($"        var {subscriptionVarName} = serviceName + \"{SubscriptionSuffix}\";");
                         sb.AppendLine();
                         
-                        // Use the correct syntax for SubscriptionEndpoint
+                        // Use the correct syntax for SubscriptionEndpoint with correct parameter order
                         sb.AppendLine($"        cfg.SubscriptionEndpoint(");
-                        sb.AppendLine($"            {topicVarName},");
-                        sb.AppendLine($"            {subscriptionVarName},");
-                        sb.AppendLine($"            e =>"); // Using lambda directly without type specification
+                        sb.AppendLine($"            {subscriptionVarName},"); // First parameter is subscriptionName
+                        sb.AppendLine($"            {topicVarName},");       // Second parameter is topicPath
+                        sb.AppendLine($"            {ConfiguratorParamName} =>"); // Third parameter is configure Action
                         sb.AppendLine("            {");
                         
                         // Add dead letter configuration if enabled


### PR DESCRIPTION
Corrects the parameter order in the SubscriptionEndpoint method calls, ensuring the subscription name is passed before the topic path.

Updates the topic name generation to directly use the entity name instead of prepending the service name. This simplifies topic naming and aligns with the intended configuration.