### PR TITLE
Adds option to control fault publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Zooper.Cheetah project will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2025-05-01
+
+### Added
+- Added option to control fault publishing with `publishFaults` parameter (defaults to false)
+
+### Changed
+- Removed unnecessary comments from generated code for cleaner output
+
 ## [1.2.2] - 2025.05.01
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.2</Version>
+        <Version>1.3.0</Version>
         <Authors>Daniel Martin</Authors>
         <Company>Zooper</Company>
         <RepositoryUrl>https://github.com/zooper-lib/cheetah</RepositoryUrl>

--- a/Zooper.Cheetah.Generators.AzureServiceBus/ReceiveEndpointSourceGenerator.cs
+++ b/Zooper.Cheetah.Generators.AzureServiceBus/ReceiveEndpointSourceGenerator.cs
@@ -125,7 +125,7 @@ public class ReceiveEndpointSourceGenerator : IIncrementalGenerator
                 sb.AppendLine($"public static class {FileName}");
                 sb.AppendLine("{");
                 sb.AppendLine(
-                    $"    public static void {MethodName}(this IServiceBusBusFactoryConfigurator cfg, IRegistrationContext context, string serviceName, bool enableDeadLettering = true)"
+                    $"    public static void {MethodName}(this IServiceBusBusFactoryConfigurator cfg, IRegistrationContext context, string serviceName, bool enableDeadLettering = true, bool publishFaults = false)"
                 );
                 sb.AppendLine("    {");
 
@@ -141,28 +141,26 @@ public class ReceiveEndpointSourceGenerator : IIncrementalGenerator
                         string topicVarName = $"topicName{consumerCounter}";
                         string subscriptionVarName = $"subscriptionName{consumerCounter}";
 
-                        // Generate variable declarations for topic and subscription names with unique names
-                        sb.AppendLine($"        // topic name for {evtSym.Name}");
                         sb.AppendLine($"        var {topicVarName} = \"{entityName}\";");
-                        sb.AppendLine($"        // subscription name");
                         sb.AppendLine($"        var {subscriptionVarName} = serviceName + \"{SubscriptionSuffix}\";");
                         sb.AppendLine();
                         
-                        // Use the correct syntax for SubscriptionEndpoint with correct parameter order
                         sb.AppendLine($"        cfg.SubscriptionEndpoint(");
-                        sb.AppendLine($"            {subscriptionVarName},"); // First parameter is subscriptionName
-                        sb.AppendLine($"            {topicVarName},");       // Second parameter is topicPath
-                        sb.AppendLine($"            {ConfiguratorParamName} =>"); // Third parameter is configure Action
+                        sb.AppendLine($"            {subscriptionVarName},");
+                        sb.AppendLine($"            {topicVarName},");
+                        sb.AppendLine($"            {ConfiguratorParamName} =>");
                         sb.AppendLine("            {");
                         
-                        // Add dead letter configuration if enabled
-                        sb.AppendLine("                // send *skipped* messages to <subscription>/$ deadletterqueue");
-                        sb.AppendLine($"                {ConfiguratorParamName}.ConfigureDeadLetterQueueDeadLetterTransport();");
-                        sb.AppendLine("                // send *faulted* messages (after retries) to <subscription>/$ deadletterqueue");
-                        sb.AppendLine($"                {ConfiguratorParamName}.ConfigureDeadLetterQueueErrorTransport();");
+                        sb.AppendLine($"                {ConfiguratorParamName}.PublishFaults = publishFaults;");
                         sb.AppendLine();
                         
-                        // Configure consumer
+                        if (true) // keeping conditional for future use
+                        {
+                            sb.AppendLine($"                {ConfiguratorParamName}.ConfigureDeadLetterQueueDeadLetterTransport();");
+                            sb.AppendLine($"                {ConfiguratorParamName}.ConfigureDeadLetterQueueErrorTransport();");
+                            sb.AppendLine();
+                        }
+                        
                         sb.AppendLine($"                {ConfiguratorParamName}.Consumer<{consumerSym.ToDisplayString()}>(context);");
                         sb.AppendLine("            });");
                         sb.AppendLine();


### PR DESCRIPTION
Adds the `publishFaults` parameter to control the publishing of faults.

Removes unnecessary comments from the generated code for cleaner output.

Updates version to 1.3.0.